### PR TITLE
Add support for valuesFrom that reference a key within a secret

### DIFF
--- a/specctl/ecs2k8s/ecs_parser.py
+++ b/specctl/ecs2k8s/ecs_parser.py
@@ -10,7 +10,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 def k8s_conform(input_string):
-    return(re.sub("[^a-zA-Z0-9]+","-", input_string).lower())
+    return(re.sub("[^a-zA-Z0-9]+","-", input_string).lower().rstrip("-"))
 
 def get_pod_iam(task_def, k8s_svc_account):
     pod_iam = task_def.get("taskRoleArn")


### PR DESCRIPTION
Currenlty the tool fails when it runs into a valuesFrom that references a key within a secret (the `secret-name:KEY::` format). This PR adds support for those references.

*Issue #, if available:*
N/A

*Description of changes:*

Replace the basic call to secretsmanager client.get_secret_value with a helper function that checks if the valuesFrom is in the `secret:key::` format. If it is, it parses it into an ARN and secret key and fetches the specific key value from within the secret.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
